### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: cpp
+compiler: gcc
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - boost-latest
+
+    packages:
+    - g++-5
+    - libboost1.55-dev
+    - libeigen3-dev
+    - libpng++-dev
+
+before_script:
+- (cd prj && ln -s def.compiler.gcc-5-ubuntu-14 def.compiler)
+- (cd prj && ln -s def.platform.linux def.platform)
+
+script:
+- (cd prj && make -j6)
+- (cd prj && make tests -j6)
+- (cd testing && ./run-all-tests.sh)

--- a/prj/def.includes
+++ b/prj/def.includes
@@ -16,6 +16,6 @@
 # BOOST_INCLUDES = -I/Users/gwesp/software/boost_1_47_0
   BOOST_INCLUDES = -I/opt/local/include -I$(HOME)/src/boost_1_58_0
   EIGEN_INCLUDES = -I/opt/local/include/eigen3 -I/usr/include/eigen3
-  PNGPP_INCLUDES = -I$(HOME)/src/png++-0.2.5
+  PNGPP_INCLUDES = -I$(HOME)/src/png++-0.2.5 -I/usr/include/png++
 
 THIRD_PARTY_INCLUDES = $(BOOST_INCLUDES) $(PNGPP_INCLUDES) $(EIGEN_INCLUDES)

--- a/prj/def.platform.linux
+++ b/prj/def.platform.linux
@@ -10,6 +10,6 @@ PNG_STUFF     = yes
 OBJ_EXTENSION = o
 LIB_EXTENSION = a
 
-PLATFORM_LIB =
+PLATFORM_LIB = -lrt -lpthread
 
 PLATFORM = linux


### PR DESCRIPTION
This PR adds support for the [Travis CI](https://travis-ci.org/) build server. Travis CI is currently running Ubuntu 12.04 LTS and so far I've only been able to make the library compile with g++ 5.0.

I've tested it with my forked repo: https://travis-ci.org/Turbo87/cpp-lib/builds/87989264

Let me know if you need help setting up this project at their page.